### PR TITLE
[FEATURE] Allow alternate labels

### DIFF
--- a/Classes/ViewHelpers/Tca/FieldLabelViewHelper.php
+++ b/Classes/ViewHelpers/Tca/FieldLabelViewHelper.php
@@ -25,7 +25,8 @@ namespace TYPO3\CMS\QuickForm\ViewHelpers\Tca;
 use TYPO3\CMS\Vidi\Tca\TcaService;
 
 /**
- * View helper which translates a label for field given by the context. Under the hood, it will search teh label from the TCA.
+ * View helper which translates a label for field given by the context.
+ * Under the hood, it will search the label from the TCA.
  */
 class FieldLabelViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper {
 
@@ -33,7 +34,9 @@ class FieldLabelViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractView
 	 * Returns a label for field given by the context.
 	 * It will search the label value from the TCA.
 	 *
-	 * @param string $key
+	 * An alternate label can be defined by using a "LLL:" reference in the key.
+	 *
+	 * @param string $key Name of a TCA field or LLL: reference
 	 * @return string
 	 */
 	public function render($key = '') {
@@ -43,7 +46,11 @@ class FieldLabelViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractView
 			$key = $this->templateVariableContainer->get('label');
 		}
 
-		return TcaService::table($dataType)->field($key)->getLabel();
+		if (strpos($key, 'LLL:') === 0) {
+			return $GLOBALS['TSFE']->sL($key);
+		} else {
+			return TcaService::table($dataType)->field($key)->getLabel();
+		}
 	}
 }
 ?>


### PR DESCRIPTION
It is convenient to be able to define labels explicitly
rather than always picking them up automatically from the TCA.

With this patch, the key can either be a field name (which is used to pick the label from the TCA) or a LLL: reference (which is interpreted directly).
